### PR TITLE
Fields, _convert_audio, expect no change

### DIFF
--- a/audiofield/fields.py
+++ b/audiofield/fields.py
@@ -118,9 +118,18 @@ class AudioField(FileField):
         '''Convert uploaded audio file to selected format'''
 
         request = threadlocals.get_current_request()
-        convert_type = int(request.POST["convert_type"])
-        channel_no = int(request.POST["channel_type"])
-        freq_value = int(request.POST["freq_type"])
+
+        convert_type = 0
+        channel_no = 0
+        freq_value = 0
+
+        if 'convert_type' in request.POST:
+          convert_type = int(request.POST["convert_type"])
+        if 'channel_no' in request.POST:
+          channel_no = int(request.POST["channel_type"])
+        if 'freq_type' in request.POST:
+          freq_value = int(request.POST["freq_type"])
+
         splitted_filename = list(os.path.splitext(filename))[0]  # converted filename without ext
 
         logger.debug("convert audio : %s->%s" % (str(ext), CONVERT_TYPE_CHK[convert_type]))


### PR DESCRIPTION
Hi, this has been raising some exceptions. I'm not using AdminAudioFileWidget, so request.POST may have 'convert_type' or 'channel_type' or 'freq_type' undefined.
