### PR TITLE
change to create Django 1.10 compatible threadlocalspy middleware

### DIFF
--- a/audiofield/middleware/threadlocals.py
+++ b/audiofield/middleware/threadlocals.py
@@ -27,7 +27,9 @@ class ThreadLocals(object):
 	Middleware that gets various objects from the
 	request object and saves them in thread local storage.
 	"""
-	
+	def process_request(self, request):
+		_thread_locals.request = request	
+
 	def __init__(self, get_response):
 		self.get_response = get_response
 
@@ -35,7 +37,12 @@ class ThreadLocals(object):
 		response = None
 
 		_thread_locals.request = request
+		
 		if hasattr(self, 'process_request'):
 			response = self.process_request(request)
 		if not response:
 			response = self.process_request(request)
+
+		self.get_response(request)
+
+		return response

--- a/audiofield/middleware/threadlocals.py
+++ b/audiofield/middleware/threadlocals.py
@@ -11,38 +11,20 @@
 # Arezqui Belaid <info@star2billing.com>
 #
 
+from django.utils.deprecation import MiddlewareMixin
 import threading
 
 _thread_locals = threading.local()
 
-# middleware updated to be compatible with Django 1.10+ 5/16/2017 per - https://docs.djangoproject.com/en/1.11/topics/http/middleware/#upgrading-middleware
-# updates on lines 22 - 23 and 35 - 41 on 5/16/2017 are to attempt to add back compatibility with Django 1.9 and prev. - testing needed
-# Issue submitted to audiofield project on github at: https://github.com/areski/django-audiofield/issues/27
 
 def get_current_request():
     return getattr(_thread_locals, 'request', None)
 
-class ThreadLocals(object): 
-	"""
-	Middleware that gets various objects from the
-	request object and saves them in thread local storage.
-	"""
-	def process_request(self, request):
-		_thread_locals.request = request	
 
-	def __init__(self, get_response):
-		self.get_response = get_response
-
-	def __call__(self, request):
-		response = None
-
-		_thread_locals.request = request
-		
-		if hasattr(self, 'process_request'):
-			response = self.process_request(request)
-		if not response:
-			response = self.process_request(request)
-
-		self.get_response(request)
-
-		return response
+class ThreadLocals(MiddlewareMixin):
+    """
+    Middleware that gets various objects from the
+    request object and saves them in thread local storage.
+    """
+    def process_request(self, request):
+        _thread_locals.request = request

--- a/audiofield/middleware/threadlocals.py
+++ b/audiofield/middleware/threadlocals.py
@@ -15,15 +15,24 @@ import threading
 
 _thread_locals = threading.local()
 
+# middleware updated to be compatible with Django 1.10+ per below
+# https://docs.djangoproject.com/en/1.11/topics/http/middleware/#upgrading-middleware
+#
+# Issue submitted to audiofield project on github at: https://github.com/areski/django-audiofield/issues/27
 
-def get_current_request():
-    return getattr(_thread_locals, 'request', None)
+class ThreadLocals(object): 
+	"""
+	Middleware that gets various objects from the
+	request object and saves them in thread local storage.
+	"""
+	
 
+	def __init__(self, get_response):
+		self.get_response = get_response
 
-class ThreadLocals(object):
-    """
-    Middleware that gets various objects from the
-    request object and saves them in thread local storage.
-    """
-    def process_request(self, request):
-        _thread_locals.request = request
+	def __call__(self, request):
+		
+
+		_thread_locals.request = request
+
+		response = self.process_request(request)

--- a/audiofield/middleware/threadlocals.py
+++ b/audiofield/middleware/threadlocals.py
@@ -15,10 +15,12 @@ import threading
 
 _thread_locals = threading.local()
 
-# middleware updated to be compatible with Django 1.10+ per below
-# https://docs.djangoproject.com/en/1.11/topics/http/middleware/#upgrading-middleware
-#
+# middleware updated to be compatible with Django 1.10+ 5/16/2017 per - https://docs.djangoproject.com/en/1.11/topics/http/middleware/#upgrading-middleware
+# updates on lines 22 - 23 and 35 - 41 on 5/16/2017 are to attempt to add back compatibility with Django 1.9 and prev. - testing needed
 # Issue submitted to audiofield project on github at: https://github.com/areski/django-audiofield/issues/27
+
+def get_current_request():
+    return getattr(_thread_locals, 'request', None)
 
 class ThreadLocals(object): 
 	"""
@@ -26,13 +28,14 @@ class ThreadLocals(object):
 	request object and saves them in thread local storage.
 	"""
 	
-
 	def __init__(self, get_response):
 		self.get_response = get_response
 
 	def __call__(self, request):
-		
+		response = None
 
 		_thread_locals.request = request
-
-		response = self.process_request(request)
+		if hasattr(self, 'process_request'):
+			response = self.process_request(request)
+		if not response:
+			response = self.process_request(request)


### PR DESCRIPTION
As noted in my [comment](https://github.com/areski/django-audiofield/pull/29#issuecomment-302247239) on PR #29 - my efforts to create a new class for ThreadLocals in the v1.10+ supported style are still unsuccessful but the doc supported fix is now working - have committed that to this branch of my fork.

As Django has said they will [remove all support for old-style 'MIDDLEWARE_CLASSES' in v2.0](https://docs.djangoproject.com/en/dev/internals/deprecation/) this should not be considered a long-term fix.