### PR TITLE
docs: Fix simple typo, requirments -> requirements

### DIFF
--- a/docs/source/installation-overview.rst
+++ b/docs/source/installation-overview.rst
@@ -39,7 +39,7 @@ Install dependencies on Redhat/CentOS::
 Install requirements
 ====================
 
-Use PIP to install the dependencies listed in the requirments file,::
+Use PIP to install the dependencies listed in the requirements file,::
 
     $ pip install -r requirements.txt
 


### PR DESCRIPTION
There is a small typo in docs/source/installation-overview.rst.

Should read `requirements` rather than `requirments`.

